### PR TITLE
Add Resolution property to Device

### DIFF
--- a/Quamotion.WebDriver.Client/Models/Device.cs
+++ b/Quamotion.WebDriver.Client/Models/Device.cs
@@ -108,5 +108,15 @@ namespace Quamotion.WebDriver.Client.Models
             get;
             set;
         }
+
+        /// <summary>
+        /// Gets or sets the resolution of the device.
+        /// </summary>
+        [JsonProperty("resolution", NullValueHandling = NullValueHandling.Ignore)]
+        public DeviceResolution Resolution
+        {
+            get;
+            set;
+        }
     }
 }

--- a/Quamotion.WebDriver.Client/Models/DeviceResolution.cs
+++ b/Quamotion.WebDriver.Client/Models/DeviceResolution.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="DeviceResolution.cs" company="Quamotion">
+// Copyright (c) Quamotion. All rights reserved.
+// </copyright>
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+
+namespace Quamotion.WebDriver.Client.Models
+{
+    /// <summary>
+    /// Represents the resolution of a <see cref="Device"/>.
+    /// </summary>
+    public class DeviceResolution
+    {
+        [JsonProperty("x")]
+        public int X
+        {
+            get;
+            set;
+        }
+
+        [JsonProperty("y")]
+        public int Y
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the width of the device screen, in pixels.
+        /// </summary>
+        [JsonProperty("width")]
+        public int Width
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the height of the device screen, in pixels.
+        /// </summary>
+        [JsonProperty("height")]
+        public int Height
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/Quamotion.WebDriver.Client/Quamotion.WebDriver.Client.csproj
+++ b/Quamotion.WebDriver.Client/Quamotion.WebDriver.Client.csproj
@@ -67,6 +67,7 @@
     <Compile Include="AppDriver.cs" />
     <Compile Include="AppDriverCommand.cs" />
     <Compile Include="KeyboardExtensions.cs" />
+    <Compile Include="Models\DeviceResolution.cs" />
     <Compile Include="TypedHttpCommandExecutor.cs" />
     <Compile Include="WebDriverExtensions.cs" />
     <Compile Include="Models\Application.cs" />


### PR DESCRIPTION
This branch adds a new `Resolution` property to the `Device` model, which enables parsing device resolution information from the Quamotion WebDriver JSON responses.