### PR TITLE
Always return the page source as a string

### DIFF
--- a/Quamotion.WebDriver.Client.Tests/AppDriverTests.cs
+++ b/Quamotion.WebDriver.Client.Tests/AppDriverTests.cs
@@ -1,0 +1,17 @@
+using System.Linq;
+using Xunit;
+
+namespace Quamotion.WebDriver.Client.Tests
+{
+    public class AppDriverTests
+    {
+        [Fact]
+        public void Test1()
+        {
+            var device = WebDriverExtensions.Devices.SingleOrDefault();
+
+            AppDriver driver = new AppDriver(new DeviceCapabilities(deviceId: device.UniqueId));
+            var source = driver.PageSource;
+        }
+    }
+}

--- a/Quamotion.WebDriver.Client.Tests/Quamotion.WebDriver.Client.Tests.csproj
+++ b/Quamotion.WebDriver.Client.Tests/Quamotion.WebDriver.Client.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Quamotion.WebDriver.Client\Quamotion.WebDriver.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Quamotion.WebDriver.Client/Quamotion.WebDriver.Client.csproj
+++ b/Quamotion.WebDriver.Client/Quamotion.WebDriver.Client.csproj
@@ -8,6 +8,7 @@
     <Product>Quamotion WebDriver</Product>
     <Copyright>(c) 2018 Quamotion bvba</Copyright>
     <PackageProjectUrl>https://github.com/quamotion/Quamotion.WebDriver</PackageProjectUrl>
+    <PackageId>quamotion-webdriver-client</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Quamotion.WebDriver.Client/TypedHttpCommandExecutor.cs
+++ b/Quamotion.WebDriver.Client/TypedHttpCommandExecutor.cs
@@ -66,7 +66,16 @@ namespace Quamotion.WebDriver.Client
         /// <inheritdoc />
         public Response Execute(Command command)
         {
-            return this.Execute<Response>(command);
+            var response = this.Execute<Response>(command);
+
+            if (command.Name == "getPageSource")
+            {
+                // The .NET Selenium client returns the page source as a string object. However, the Response command will attempt to serialize
+                // this as a dictionary. Convert this back to a string value to make sure we return the correct value.
+                response.Value = JsonConvert.SerializeObject(response);
+            }
+
+            return response;
         }
 
         /// <summary>

--- a/Quamotion.WebDriver.sln
+++ b/Quamotion.WebDriver.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27428.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quamotion.WebDriver.Client", "Quamotion.WebDriver.Client\Quamotion.WebDriver.Client.csproj", "{C5217932-3FEA-45DD-B1AF-F8FB9268CCC0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quamotion.WebDriver.Client.Tests", "Quamotion.WebDriver.Client.Tests\Quamotion.WebDriver.Client.Tests.csproj", "{95292DA9-D6DA-45BA-8FB0-B57B4C4E8608}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,8 +17,15 @@ Global
 		{C5217932-3FEA-45DD-B1AF-F8FB9268CCC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C5217932-3FEA-45DD-B1AF-F8FB9268CCC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C5217932-3FEA-45DD-B1AF-F8FB9268CCC0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95292DA9-D6DA-45BA-8FB0-B57B4C4E8608}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95292DA9-D6DA-45BA-8FB0-B57B4C4E8608}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95292DA9-D6DA-45BA-8FB0-B57B4C4E8608}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95292DA9-D6DA-45BA-8FB0-B57B4C4E8608}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F8CA182F-6365-4B59-AB4B-46DE6A54BC7B}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
The .NET bindings for Selenium expect the page source to be a `string`,  so make sure it's always that. If the page source is a JSON object, convert it back to its string representation.